### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT/Apache-2.0"
 readme = "README.rst"
 keywords = ["linux", "monitoring", "meter"]
 categories = ["api-bindings"]
-homepage = "http://github.com/tailhook/libcantal"
-documentation = "http://tailhook.github.io/libcantal/"
+homepage = "https://github.com/tailhook/cantal-rs"
+documentation = "https://docs.rs/libcantal/"
 version = "0.3.1"
 authors = ["paul@colomiets.name"]
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -140,7 +140,7 @@ fn read_and_map<'x, T: Collection + ?Sized>(coll: &'x T)
         let mut pair = line.splitn(2, ":");
         let mut type_iter = pair.next().unwrap().split(' ');
         let kind = type_iter.next().unwrap();
-        let size = type_iter.next()
+        let size: i32 = type_iter.next()
             .ok_or_else(|| ErrorEnum::InvalidMeta(
                 meta_path.clone(), "Unsized type"))?
             .parse().map_err(|_| ErrorEnum::InvalidMeta(


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that src/read.rs:143 line will have a type ambiguity error, so this is a PR to preemptively prevent that. I'm not shur I got the correct type for `size` it appears to a `&str` as it comes from `.split(' ')` but it must be an int as you add it to `offset`. I am on windows so the compiler did not help as `#[cfg(unix)]`.

Also in trying to make this pr I noted that https://crates.io/crates/libcantal has out of date links so I updated you toml file.